### PR TITLE
Update __init__.py

### DIFF
--- a/tinker_partner_api/__init__.py
+++ b/tinker_partner_api/__init__.py
@@ -21,7 +21,7 @@ if False:
 class TinkerPartnerAPI():
     def __init__(self, production=False, baseUrl=False, app_id=None, api_key=None):
         subdomain = production and 'api' or 'sandbox'
-        self.baseUrl = baseUrl or 'https://{}.tinker.taxi/api'.format(subdomain)
+        self.baseUrl = baseUrl or 'https://{}.tinker.taxi'.format(subdomain)
         self.client = tinker.ApiClient(host=self.baseUrl)
         self.booking = tinker.PartnerBookingApi(api_client=self.client)
         self.contact = tinker.CustomerApi(api_client=self.client)


### PR DESCRIPTION
removed the /api part from the baseUrl.
since the ESB already takes care of this.

Please note that the release of this library means:
1. nginx needs to be updated to send to the esb for both prd and acc (esb was already ready for that)
2. Mozio will wait with going live until this library is updated
3. developer.tinker.travel needs to be checked if it still includes the /api part in the url
